### PR TITLE
Use mktemp to create temp file. (Security fix!)

### DIFF
--- a/ban.sh
+++ b/ban.sh
@@ -2,7 +2,7 @@
 
 command -v jq >/dev/null 2>&1 || { echo >&2 "Please install \"jq\" first. Aborting."; exit 1; }
 
-NODES_FILE='/tmp/segshit-nodes.txt'
+NODES_FILE="`mktemp /tmp/segshit-nodes.XXXXXXXXXX`"
 BAN_TIME="5184000"
 
 # Download the latest nodes snapshot


### PR DESCRIPTION
This fixes potential security issue when there's already symlink with
same name in /tmp pointing somewhere user doesn't want to (e.g.
/home/user/.bitcoin/wallet.dat)